### PR TITLE
Use transition adapter instead of transition listener where appropriate

### DIFF
--- a/app/src/main/java/com/mikescamell/locomotionlayout/CombinedSceneLol.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/CombinedSceneLol.kt
@@ -1,5 +1,7 @@
 package com.mikescamell.locomotionlayout
 
+import android.graphics.Color
+import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.View
@@ -7,6 +9,8 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
+import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
 import kotlinx.android.synthetic.main.layout2_part4.*
@@ -38,43 +42,20 @@ class CombinedSceneLol : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Boolean,
-                progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
-                motionLayout: MotionLayout?,
+                motionLayout: MotionLayout,
                 startId: Int,
                 endId: Int,
                 progress: Float
             ) {
-                if (startId == R.id.middle) {
-                    /*val color =
-                        ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
-                    bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                    bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)*/
-                }
+                val color =
+                    ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
+                bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+                bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout?, p1: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart1.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart1.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,45 +42,21 @@ class CombinedScenePart1 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Boolean,
-                progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
-                motionLayout: MotionLayout?,
+                motionLayout: MotionLayout,
                 startId: Int,
                 endId: Int,
                 progress: Float
             ) {
-                if (startId == R.id.middle) {
-                    val color =
-                        ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
-                    bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                    bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                }
+                val color =
+                    ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
+                bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+                bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout?, p1: Int) {
-            }
         })
-
         topLeftAnimationForward?.registerAnimationCallback(object :
             Animatable2Compat.AnimationCallback() {
             override fun onAnimationEnd(drawable: Drawable?) {

--- a/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart2.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart2.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,43 +42,20 @@ class CombinedScenePart2 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Boolean,
-                progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
-                motionLayout: MotionLayout?,
+                motionLayout: MotionLayout,
                 startId: Int,
                 endId: Int,
                 progress: Float
             ) {
-                if (startId == R.id.middle) {
-                    val color =
-                        ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
-                    bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                    bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                }
+                val color =
+                    ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
+                bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+                bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout?, p1: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart3.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/CombinedScenePart3.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,43 +42,20 @@ class CombinedScenePart3 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Boolean,
-                progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout?,
-                startId: Int,
-                endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
-                motionLayout: MotionLayout?,
+                motionLayout: MotionLayout,
                 startId: Int,
                 endId: Int,
                 progress: Float
             ) {
-                if (startId == R.id.middle) {
-                    val color =
-                        ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
-                    bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                    bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
-                }
+                val color =
+                    ColorUtils.setAlphaComponent(Color.WHITE, calculateProgressAlpha(progress))
+                bottomRightAnimationForward?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+                bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout?, p1: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/MikezoActivity.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/MikezoActivity.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
-import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.mikezo_cards.*
@@ -93,29 +93,7 @@ class MikezoActivity : AppCompatActivity() {
     }
 
     private fun collapsedCardCompletedListener(@IdRes endStateId: Int) {
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout, startId: Int, endId: Boolean, progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout, startId: Int, endId: Int
-            ) {
-            }
-
-            override fun onTransitionChange(
-                motionLayout: MotionLayout,
-                startId: Int,
-                endId: Int,
-                progress: Float
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
                 if (currentId == R.id.topCardOnTop) {

--- a/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part4.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part4.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
-import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -44,21 +44,7 @@ class Scene2Part4 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout, startId: Int, endId: Boolean, progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout, startId: Int, endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
                 motionLayout: MotionLayout,
@@ -72,8 +58,6 @@ class Scene2Part4 : AppCompatActivity() {
                 bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part5.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part5.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,21 +42,7 @@ class Scene2Part5 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout, startId: Int, endId: Boolean, progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout, startId: Int, endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
                 motionLayout: MotionLayout,
@@ -69,8 +56,6 @@ class Scene2Part5 : AppCompatActivity() {
                 bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part6.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part6.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,21 +42,7 @@ class Scene2Part6 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout, startId: Int, endId: Boolean, progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout, startId: Int, endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
                 motionLayout: MotionLayout,
@@ -69,8 +56,6 @@ class Scene2Part6 : AppCompatActivity() {
                 bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :

--- a/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part7.kt
+++ b/app/src/main/java/com/mikescamell/locomotionlayout/Scene2Part7.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionScene
+import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.graphics.ColorUtils
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
@@ -41,21 +42,7 @@ class Scene2Part7 : AppCompatActivity() {
                 setImageDrawable(bottomRightAnimationForward)
             }
 
-        root.setTransitionListener(object : MotionLayout.TransitionListener {
-
-            override fun allowsTransition(transition: MotionScene.Transition): Boolean {
-                return true
-            }
-
-            override fun onTransitionTrigger(
-                motionLayout: MotionLayout, startId: Int, endId: Boolean, progress: Float
-            ) {
-            }
-
-            override fun onTransitionStarted(
-                motionLayout: MotionLayout, startId: Int, endId: Int
-            ) {
-            }
+        root.setTransitionListener(object : TransitionAdapter() {
 
             override fun onTransitionChange(
                 motionLayout: MotionLayout,
@@ -69,8 +56,6 @@ class Scene2Part7 : AppCompatActivity() {
                 bottomRightAnimationReverse?.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
             }
 
-            override fun onTransitionCompleted(motionLayout: MotionLayout, currentId: Int) {
-            }
         })
 
         topLeftAnimationForward?.registerAnimationCallback(object :


### PR DESCRIPTION
This means we don't have to override callbacks we're not using